### PR TITLE
fix: Fixed IndexOutOfRange exception when building a project with analyzers

### DIFF
--- a/roslyn/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/roslyn/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -866,6 +866,11 @@ namespace Microsoft.CodeAnalysis
             int i = 0;
             foreach (var syntaxTree in syntaxTrees)
             {
+                // Skip auto-generated files. No need to check them with analyzers.
+                if (syntaxTree.FilePath.Length == 0)
+                {
+                    continue;
+                }
 
                 var options = sourceFileAnalyzerConfigOptions[i].AnalyzerOptions;
 


### PR DESCRIPTION
When building a project with analyzers, Roslyn expects that SyntaxTree length equals the sourceFileAnalyzerConfigOptions length. However, because we add one more script to SyntaxTree, their lengths don't match and it causes the IndexOutOfRange exception. We don't need to check auto-generated files with analyzers, so skipping them resolves the issue.